### PR TITLE
修复微博页面异步加载导致脚本初始化失败的问题，加入重试机制

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,36 +38,65 @@
 // ==/UserScript==
 
 (async function () {
-    const $frameContent = $('.Frame_content_3XrxZ')
-    const $mMain = $('.m-main')
-    const $newMain = $('._content_1ubn9_18')
-    let $main = ''
-    let $cardList = ''
-    let cardHeadStr = ''
-    let cardHeadAStr = ''
-    if ($mMain.length) {
-        // 搜索页面
-        $main = $mMain
-        $cardList = $('.main-full')
-        cardHeadStr = 'div.card-feed  div.from'
-        cardHeadAStr = 'a[suda-data]'
-    } else if ($frameContent.length) {
-        // 默认页面
-        $main = $frameContent
-        // .Frame_wrap_16as0 微博个人主页里面的相册
-        $cardList = $('.Main_full_1dfQX,.Frame_wrap_16as0')
-        cardHeadStr = '.head-info_info_2AspQ'
-        cardHeadAStr = '.head-info_time_6sFQg'
-    } else if ($newMain.length) {
-        // 默认页面
-        $main = $newMain
-        // ._wrap_100l0_2  微博个人主页里面的相册
-        $cardList = $('._full_1l406_7,._wrap_100l0_2')
-        cardHeadStr = '._info_1tpft_10'
-        cardHeadAStr = '._time_1tpft_33'
-    } else {
-        return false
+    // 定义初始化函数
+    async function init() {
+        const $frameContent = $('.Frame_content_3XrxZ');
+        const $mMain = $('.m-main');
+        const $newMain = $('._content_1ubn9_18');
+        
+        let $main = '';
+        let $cardList = '';
+        let cardHeadStr = '';
+        let cardHeadAStr = '';
+
+        if ($mMain.length) {
+            $main = $mMain;
+            $cardList = $('.main-full');
+            cardHeadStr = 'div.card-feed  div.from';
+            cardHeadAStr = 'a[suda-data]';
+        } else if ($frameContent.length) {
+            $main = $frameContent;
+            $cardList = $('.Main_full_1dfQX,.Frame_wrap_16as0');
+            cardHeadStr = '.head-info_info_2AspQ';
+            cardHeadAStr = '.head-info_time_6sFQg';
+        } else if ($newMain.length) {
+            $main = $newMain;
+            $cardList = $('._full_1l406_7,._wrap_100l0_2');
+            cardHeadStr = '._info_1tpft_10';
+            cardHeadAStr = '._time_1tpft_33';
+        }
+
+        // 如果没找到对应的容器，返回 null
+        if (!$main || !$main.length) {
+            return null;
+        }
+
+        return { $main, $cardList, cardHeadStr, cardHeadAStr };
     }
+
+    // 循环等待页面加载
+    let setup = null;
+    let retryCount = 0;
+    const waitInterval = 0.5 * 1000; // 每次等 0.5 秒
+    const maxWaitTime = 10 * 1000; // 总共最多等 10 秒
+    const maxRetries = maxWaitTime / waitInterval; // 自动算出次数是 20 次
+
+    while (retryCount < maxRetries) {
+        setup = await init();
+        if (setup) break; // 元素加载成功，跳出循环
+        
+        retryCount++;
+        console.log(`等待微博页面加载中... (${retryCount}/${maxRetries})`);
+        await new Promise(resolve => setTimeout(resolve, waitInterval)); // 等 500 毫秒
+    }
+
+    if (!setup) {
+        console.log('脚本退出：未找到微博内容容器，可能是类名已更改。');
+        return false;
+    }
+
+    // 解构获取到的变量，继续执行
+    const { $main, $cardList, cardHeadStr, cardHeadAStr } = setup;
 
     // 第一次使用
     let isFirst = GM_getValue('isFirst', true)


### PR DESCRIPTION
您好！感谢维护这个非常有用的脚本。

在测试过程中，我发现脚本在某些情况下（尤其是网络较慢或微博新版页面加载时）偶尔无法显示下载按钮。通过调试发现，原因是脚本在 document-idle 时刻运行，但此时微博的动态内容（如 .m-main 或 ._content_1ubn9_18 等容器）可能尚未完成渲染，导致脚本在原代码第 69 行处直接退出。

**修改内容**：

**引入轮询机制**：将初始化逻辑封装，如果未检测到页面核心元素，脚本将每隔 500ms 重试一次。

**设置超时限制**：设定了最大重试次数（20次，约 10 秒），确保脚本不会无限循环，同时也给了异步页面足够的加载时间。

**提高稳定性**：解决了“有时有按钮，有时没按钮”的随机 bug。

**测试情况**： 在 Chrome 环境下，针对新版微博首页、个人主页和搜索页面进行了多次刷新测试，下载按钮的加载成功率显著提升。